### PR TITLE
introspection: Keep user-defined order for arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  go:
+    name: go
+    runs-on: ubuntu-22.04-16c-64g-600gb
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v3
+      - run: go test -v ./...

--- a/abstract_test.go
+++ b/abstract_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 type testDog struct {

--- a/benchutil/list_schema.go
+++ b/benchutil/list_schema.go
@@ -3,7 +3,7 @@ package benchutil
 import (
 	"fmt"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 type color struct {

--- a/benchutil/wide_schema.go
+++ b/benchutil/wide_schema.go
@@ -3,7 +3,7 @@ package benchutil
 import (
 	"fmt"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 func WideSchemaWithXFieldsAndYItems(x int, y int) graphql.Schema {

--- a/definition.go
+++ b/definition.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"regexp"
 
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/language/ast"
 )
 
 // Type interface for all of the possible kinds of GraphQL types
@@ -193,13 +193,12 @@ func GetNamed(ttype Type) Named {
 //
 // Example:
 //
-//    var OddType = new Scalar({
-//      name: 'Odd',
-//      serialize(value) {
-//        return value % 2 === 1 ? value : null;
-//      }
-//    });
-//
+//	var OddType = new Scalar({
+//	  name: 'Odd',
+//	  serialize(value) {
+//	    return value % 2 === 1 ? value : null;
+//	  }
+//	});
 type Scalar struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -306,19 +305,19 @@ func (st *Scalar) Error() error {
 // have a name, but most importantly describe their fields.
 // Example:
 //
-//    var AddressType = new Object({
-//      name: 'Address',
-//      fields: {
-//        street: { type: String },
-//        number: { type: Int },
-//        formatted: {
-//          type: String,
-//          resolve(obj) {
-//            return obj.number + ' ' + obj.street
-//          }
-//        }
-//      }
-//    });
+//	var AddressType = new Object({
+//	  name: 'Address',
+//	  fields: {
+//	    street: { type: String },
+//	    number: { type: Int },
+//	    formatted: {
+//	      type: String,
+//	      resolve(obj) {
+//	        return obj.number + ' ' + obj.street
+//	      }
+//	    }
+//	  }
+//	});
 //
 // When two types need to refer to each other, or a type needs to refer to
 // itself in a field, you can use a function expression (aka a closure or a
@@ -326,13 +325,13 @@ func (st *Scalar) Error() error {
 //
 // Example:
 //
-//    var PersonType = new Object({
-//      name: 'Person',
-//      fields: () => ({
-//        name: { type: String },
-//        bestFriend: { type: PersonType },
-//      })
-//    });
+//	var PersonType = new Object({
+//	  name: 'Person',
+//	  fields: () => ({
+//	    name: { type: String },
+//	    bestFriend: { type: PersonType },
+//	  })
+//	});
 //
 // /
 type Object struct {
@@ -669,14 +668,12 @@ func (st *Argument) Error() error {
 //
 // Example:
 //
-//     var EntityType = new Interface({
-//       name: 'Entity',
-//       fields: {
-//         name: { type: String }
-//       }
-//     });
-//
-//
+//	var EntityType = new Interface({
+//	  name: 'Entity',
+//	  fields: {
+//	    name: { type: String }
+//	  }
+//	});
 type Interface struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -780,18 +777,18 @@ func (it *Interface) Error() error {
 //
 // Example:
 //
-//     var PetType = new Union({
-//       name: 'Pet',
-//       types: [ DogType, CatType ],
-//       resolveType(value) {
-//         if (value instanceof Dog) {
-//           return DogType;
-//         }
-//         if (value instanceof Cat) {
-//           return CatType;
-//         }
-//       }
-//     });
+//	var PetType = new Union({
+//	  name: 'Pet',
+//	  types: [ DogType, CatType ],
+//	  resolveType(value) {
+//	    if (value instanceof Dog) {
+//	      return DogType;
+//	    }
+//	    if (value instanceof Cat) {
+//	      return CatType;
+//	    }
+//	  }
+//	});
 type Union struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -1086,18 +1083,18 @@ func (gt *Enum) getNameLookup() map[string]*EnumValueDefinition {
 // An input object defines a structured collection of fields which may be
 // supplied to a field argument.
 //
-// Using `NonNull` will ensure that a value must be provided by the query
+// # Using `NonNull` will ensure that a value must be provided by the query
 //
 // Example:
 //
-//     var GeoPoint = new InputObject({
-//       name: 'GeoPoint',
-//       fields: {
-//         lat: { type: new NonNull(Float) },
-//         lon: { type: new NonNull(Float) },
-//         alt: { type: Float, defaultValue: 0 },
-//       }
-//     });
+//	var GeoPoint = new InputObject({
+//	  name: 'GeoPoint',
+//	  fields: {
+//	    lat: { type: new NonNull(Float) },
+//	    lon: { type: new NonNull(Float) },
+//	    alt: { type: Float, defaultValue: 0 },
+//	  }
+//	});
 type InputObject struct {
 	PrivateName        string `json:"name"`
 	PrivateDescription string `json:"description"`
@@ -1236,14 +1233,13 @@ func (gt *InputObject) Error() error {
 //
 // Example:
 //
-//     var PersonType = new Object({
-//       name: 'Person',
-//       fields: () => ({
-//         parents: { type: new List(Person) },
-//         children: { type: new List(Person) },
-//       })
-//     })
-//
+//	var PersonType = new Object({
+//	  name: 'Person',
+//	  fields: () => ({
+//	    parents: { type: new List(Person) },
+//	    children: { type: new List(Person) },
+//	  })
+//	})
 type List struct {
 	OfType Type `json:"ofType"`
 
@@ -1287,12 +1283,12 @@ func (gl *List) Error() error {
 //
 // Example:
 //
-//     var RowType = new Object({
-//       name: 'Row',
-//       fields: () => ({
-//         id: { type: new NonNull(String) },
-//       })
-//     })
+//	var RowType = new Object({
+//	  name: 'Row',
+//	  fields: () => ({
+//	    id: { type: new NonNull(String) },
+//	  })
+//	})
 //
 // Note: the enforcement of non-nullability occurs within the executor.
 type NonNull struct {

--- a/definition.go
+++ b/definition.go
@@ -539,8 +539,8 @@ func defineFieldMap(ttype Named, fieldMap Fields) (FieldDefinitionMap, error) {
 		}
 
 		fieldDef.Args = []*Argument{}
-		for argName, arg := range field.Args {
-			if err = assertValidName(argName); err != nil {
+		for _, arg := range field.Args {
+			if err = assertValidName(arg.Name); err != nil {
 				return resultFieldMap, err
 			}
 			if err = invariantf(
@@ -551,12 +551,12 @@ func defineFieldMap(ttype Named, fieldMap Fields) (FieldDefinitionMap, error) {
 			}
 			if err = invariantf(
 				arg.Type != nil,
-				`%v.%v(%v:) argument type must be Input Type but got: %v.`, ttype, fieldName, argName, arg.Type,
+				`%v.%v(%v:) argument type must be Input Type but got: %v.`, ttype, fieldName, arg.Name, arg.Type,
 			); err != nil {
 				return resultFieldMap, err
 			}
 			fieldArg := &Argument{
-				PrivateName:        argName,
+				PrivateName:        arg.Name,
 				PrivateDescription: arg.Description,
 				Type:               arg.Type,
 				DefaultValue:       arg.DefaultValue,
@@ -612,9 +612,10 @@ type Field struct {
 	Description       string              `json:"description"`
 }
 
-type FieldConfigArgument map[string]*ArgumentConfig
+type FieldConfigArgument []*ArgumentConfig
 
 type ArgumentConfig struct {
+	Name         string
 	Type         Input       `json:"type"`
 	DefaultValue interface{} `json:"defaultValue"`
 	Description  string      `json:"description"`

--- a/definition_test.go
+++ b/definition_test.go
@@ -35,10 +35,12 @@ var blogAuthor = graphql.NewObject(graphql.ObjectConfig{
 		"pic": &graphql.Field{
 			Type: blogImage,
 			Args: graphql.FieldConfigArgument{
-				"width": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "width",
 					Type: graphql.Int,
 				},
-				"height": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "height",
 					Type: graphql.Int,
 				},
 			},
@@ -73,7 +75,8 @@ var blogQuery = graphql.NewObject(graphql.ObjectConfig{
 		"article": &graphql.Field{
 			Type: blogArticle,
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.String,
 				},
 			},
@@ -90,7 +93,8 @@ var blogMutation = graphql.NewObject(graphql.ObjectConfig{
 		"writeArticle": &graphql.Field{
 			Type: blogArticle,
 			Args: graphql.FieldConfigArgument{
-				"title": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "title",
 					Type: graphql.String,
 				},
 			},
@@ -104,7 +108,8 @@ var blogSubscription = graphql.NewObject(graphql.ObjectConfig{
 		"articleSubscribe": &graphql.Field{
 			Type: blogArticle,
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.String,
 				},
 			},
@@ -300,7 +305,8 @@ func TestTypeSystem_DefinitionExample_IncludesNestedInputObjectsInTheMap(t *test
 			"mutateSomething": &graphql.Field{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: someInputObject,
 					},
 				},
@@ -313,7 +319,8 @@ func TestTypeSystem_DefinitionExample_IncludesNestedInputObjectsInTheMap(t *test
 			"subscribeToSomething": &graphql.Field{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: someInputObject,
 					},
 				},
@@ -533,7 +540,8 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		"field2": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.String,
 				},
 			},
@@ -558,7 +566,8 @@ func TestTypeSystem_DefinitionExample_DoesNotMutatePassedFieldDefinitions(t *tes
 		"field2": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.String,
 				},
 			},

--- a/definition_test.go
+++ b/definition_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 var blogImage = graphql.NewObject(graphql.ObjectConfig{

--- a/directives.go
+++ b/directives.go
@@ -73,15 +73,15 @@ func NewDirective(config DirectiveConfig) *Directive {
 
 	args := []*Argument{}
 
-	for argName, argConfig := range config.Args {
-		if dir.err = assertValidName(argName); dir.err != nil {
+	for _, arg := range config.Args {
+		if dir.err = assertValidName(arg.Name); dir.err != nil {
 			return dir
 		}
 		args = append(args, &Argument{
-			PrivateName:        argName,
-			PrivateDescription: argConfig.Description,
-			Type:               argConfig.Type,
-			DefaultValue:       argConfig.DefaultValue,
+			PrivateName:        arg.Name,
+			PrivateDescription: arg.Description,
+			Type:               arg.Type,
+			DefaultValue:       arg.DefaultValue,
 		})
 	}
 
@@ -103,7 +103,8 @@ var IncludeDirective = NewDirective(DirectiveConfig{
 		DirectiveLocationInlineFragment,
 	},
 	Args: FieldConfigArgument{
-		"if": &ArgumentConfig{
+		&ArgumentConfig{
+			Name:        "if",
 			Type:        NewNonNull(Boolean),
 			Description: "Included when true.",
 		},
@@ -116,7 +117,8 @@ var SkipDirective = NewDirective(DirectiveConfig{
 	Description: "Directs the executor to skip this field or fragment when the `if` " +
 		"argument is true.",
 	Args: FieldConfigArgument{
-		"if": &ArgumentConfig{
+		&ArgumentConfig{
+			Name:        "if",
 			Type:        NewNonNull(Boolean),
 			Description: "Skipped when true.",
 		},
@@ -133,7 +135,8 @@ var DeprecatedDirective = NewDirective(DirectiveConfig{
 	Name:        "deprecated",
 	Description: "Marks an element of a GraphQL schema as no longer supported.",
 	Args: FieldConfigArgument{
-		"reason": &ArgumentConfig{
+		&ArgumentConfig{
+			Name: "reason",
 			Type: String,
 			Description: "Explains why this element was deprecated, usually also including a " +
 				"suggestion for how to access supported similar data. Formatted" +

--- a/directives_test.go
+++ b/directives_test.go
@@ -115,7 +115,8 @@ func TestDirectives_DirectiveArgNamesMustBeValid(t *testing.T) {
 		Description: "Directs the executor to skip this field or fragment when the `if` " +
 			"argument is true.",
 		Args: graphql.FieldConfigArgument{
-			"123if": &graphql.ArgumentConfig{
+			&graphql.ArgumentConfig{
+				Name:        "123if",
 				Type:        graphql.NewNonNull(graphql.Boolean),
 				Description: "Skipped when true.",
 			},

--- a/directives_test.go
+++ b/directives_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 var directivesTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -30,13 +30,16 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 		"colorEnum": &graphql.Field{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
-				"fromEnum": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "fromEnum",
 					Type: enumTypeTestColorType,
 				},
-				"fromInt": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "fromInt",
 					Type: graphql.Int,
 				},
-				"fromString": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "fromString",
 					Type: graphql.String,
 				},
 			},
@@ -56,10 +59,12 @@ var enumTypeTestQueryType = graphql.NewObject(graphql.ObjectConfig{
 		"colorInt": &graphql.Field{
 			Type: graphql.Int,
 			Args: graphql.FieldConfigArgument{
-				"fromEnum": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "fromEnum",
 					Type: enumTypeTestColorType,
 				},
-				"fromInt": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "fromInt",
 					Type: graphql.Int,
 				},
 			},
@@ -81,7 +86,8 @@ var enumTypeTestMutationType = graphql.NewObject(graphql.ObjectConfig{
 		"favoriteEnum": &graphql.Field{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
-				"color": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "color",
 					Type: enumTypeTestColorType,
 				},
 			},
@@ -101,7 +107,8 @@ var enumTypeTestSubscriptionType = graphql.NewObject(graphql.ObjectConfig{
 		"subscribeToEnum": &graphql.Field{
 			Type: enumTypeTestColorType,
 			Args: graphql.FieldConfigArgument{
-				"color": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "color",
 					Type: enumTypeTestColorType,
 				},
 			},

--- a/enum_type_test.go
+++ b/enum_type_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 var enumTypeTestColorType = graphql.NewEnum(graphql.EnumConfig{

--- a/examples/concurrent-resolvers/main.go
+++ b/examples/concurrent-resolvers/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 type Foo struct {

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 var Schema graphql.Schema

--- a/examples/crud/main.go
+++ b/examples/crud/main.go
@@ -70,7 +70,8 @@ var queryType = graphql.NewObject(
 				Type:        productType,
 				Description: "Get product by id",
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "id",
 						Type: graphql.Int,
 					},
 				},
@@ -110,13 +111,16 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 			Type:        productType,
 			Description: "Create new product",
 			Args: graphql.FieldConfigArgument{
-				"name": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "name",
 					Type: graphql.NewNonNull(graphql.String),
 				},
-				"info": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "info",
 					Type: graphql.String,
 				},
-				"price": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "price",
 					Type: graphql.NewNonNull(graphql.Float),
 				},
 			},
@@ -140,16 +144,20 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 			Type:        productType,
 			Description: "Update product by id",
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.NewNonNull(graphql.Int),
 				},
-				"name": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "name",
 					Type: graphql.String,
 				},
-				"info": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "info",
 					Type: graphql.String,
 				},
-				"price": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "price",
 					Type: graphql.Float,
 				},
 			},
@@ -185,7 +193,8 @@ var mutationType = graphql.NewObject(graphql.ObjectConfig{
 			Type:        productType,
 			Description: "Delete product by id",
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.NewNonNull(graphql.Int),
 				},
 			},

--- a/examples/crud/main.go
+++ b/examples/crud/main.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 // Product contains information about one product

--- a/examples/custom-scalar-type/main.go
+++ b/examples/custom-scalar-type/main.go
@@ -79,7 +79,8 @@ func main() {
 				"customers": &graphql.Field{
 					Type: graphql.NewList(CustomerType),
 					Args: graphql.FieldConfigArgument{
-						"id": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "id",
 							Type: CustomScalarType,
 						},
 					},

--- a/examples/custom-scalar-type/main.go
+++ b/examples/custom-scalar-type/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/language/ast"
 )
 
 type CustomID struct {

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 func main() {

--- a/examples/http-post/main.go
+++ b/examples/http-post/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/examples/todo/schema"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/examples/todo/schema"
 )
 
 type postData struct {

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 type user struct {
@@ -17,10 +17,11 @@ type user struct {
 var data map[string]user
 
 /*
-   Create User object type with fields "id" and "name" by using GraphQLObjectTypeConfig:
-       - Name: name of object type
-       - Fields: a map of fields by using GraphQLFields
-   Setup type of field use GraphQLFieldConfig
+Create User object type with fields "id" and "name" by using GraphQLObjectTypeConfig:
+  - Name: name of object type
+  - Fields: a map of fields by using GraphQLFields
+
+Setup type of field use GraphQLFieldConfig
 */
 var userType = graphql.NewObject(
 	graphql.ObjectConfig{
@@ -37,13 +38,14 @@ var userType = graphql.NewObject(
 )
 
 /*
-   Create Query object type with fields "user" has type [userType] by using GraphQLObjectTypeConfig:
-       - Name: name of object type
-       - Fields: a map of fields by using GraphQLFields
-   Setup type of field use GraphQLFieldConfig to define:
-       - Type: type of field
-       - Args: arguments to query with current field
-       - Resolve: function to query data using params from [Args] and return value with current type
+Create Query object type with fields "user" has type [userType] by using GraphQLObjectTypeConfig:
+  - Name: name of object type
+  - Fields: a map of fields by using GraphQLFields
+
+Setup type of field use GraphQLFieldConfig to define:
+  - Type: type of field
+  - Args: arguments to query with current field
+  - Resolve: function to query data using params from [Args] and return value with current type
 */
 var queryType = graphql.NewObject(
 	graphql.ObjectConfig{
@@ -98,7 +100,7 @@ func main() {
 	http.ListenAndServe(":8080", nil)
 }
 
-//Helper function to import json from file to map
+// Helper function to import json from file to map
 func importJSONDataFromFile(fileName string, result interface{}) (isOK bool) {
 	isOK = true
 	content, err := ioutil.ReadFile(fileName)

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -52,7 +52,8 @@ var queryType = graphql.NewObject(
 			"user": &graphql.Field{
 				Type: userType,
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "id",
 						Type: graphql.String,
 					},
 				},

--- a/examples/httpdynamic/main.go
+++ b/examples/httpdynamic/main.go
@@ -72,15 +72,16 @@ func importJSONDataFromFile(fileName string) error {
 	}
 
 	fields := make(graphql.Fields)
-	args := make(graphql.FieldConfigArgument)
+	args := graphql.FieldConfigArgument{}
 	for _, item := range data {
 		for k := range item {
 			fields[k] = &graphql.Field{
 				Type: graphql.String,
 			}
-			args[k] = &graphql.ArgumentConfig{
+			args = append(args, &graphql.ArgumentConfig{
+				Name: k,
 				Type: graphql.String,
-			}
+			})
 		}
 	}
 

--- a/examples/httpdynamic/main.go
+++ b/examples/httpdynamic/main.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 /*****************************************************************************/

--- a/examples/modify-context/main.go
+++ b/examples/modify-context/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 type User struct {

--- a/examples/sql-nullstring/main.go
+++ b/examples/sql-nullstring/main.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/language/ast"
 )
 
 // NullString to be used in place of sql.NullString

--- a/examples/sql-nullstring/main.go
+++ b/examples/sql-nullstring/main.go
@@ -4,9 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
-	"log"
 )
 
 // NullString to be used in place of sql.NullString
@@ -128,7 +129,8 @@ func main() {
 				"people": &graphql.Field{
 					Type: graphql.NewList(PersonType),
 					Args: graphql.FieldConfigArgument{
-						"favorite_dog": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "favorite_dog",
 							Type: NullableString,
 						},
 					},

--- a/examples/star-wars/main.go
+++ b/examples/star-wars/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 func main() {

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/examples/todo/schema"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/examples/todo/schema"
 )
 
 func init() {

--- a/examples/todo/schema/schema.go
+++ b/examples/todo/schema/schema.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"math/rand"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 var TodoList []Todo

--- a/examples/todo/schema/schema.go
+++ b/examples/todo/schema/schema.go
@@ -54,7 +54,8 @@ var rootMutation = graphql.NewObject(graphql.ObjectConfig{
 			Type:        todoType, // the return type for this field
 			Description: "Create new todo",
 			Args: graphql.FieldConfigArgument{
-				"text": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "text",
 					Type: graphql.NewNonNull(graphql.String),
 				},
 			},
@@ -91,10 +92,12 @@ var rootMutation = graphql.NewObject(graphql.ObjectConfig{
 			Type:        todoType, // the return type for this field
 			Description: "Update existing todo, mark it done or not done",
 			Args: graphql.FieldConfigArgument{
-				"done": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "done",
 					Type: graphql.Boolean,
 				},
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.NewNonNull(graphql.String),
 				},
 			},
@@ -135,7 +138,8 @@ var rootQuery = graphql.NewObject(graphql.ObjectConfig{
 			Type:        todoType,
 			Description: "Get single todo",
 			Args: graphql.FieldConfigArgument{
-				"id": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "id",
 					Type: graphql.String,
 				},
 			},

--- a/executor.go
+++ b/executor.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
 )
 
 type ExecuteParams struct {

--- a/executor_resolve_test.go
+++ b/executor_resolve_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 func testSchema(t *testing.T, testField *graphql.Field) graphql.Schema {

--- a/executor_resolve_test.go
+++ b/executor_resolve_test.go
@@ -2,10 +2,11 @@ package graphql_test
 
 import (
 	"encoding/json"
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
 	"reflect"
 	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
 )
 
 func testSchema(t *testing.T, testField *graphql.Field) graphql.Schema {
@@ -71,8 +72,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 	schema := testSchema(t, &graphql.Field{
 		Type: graphql.String,
 		Args: graphql.FieldConfigArgument{
-			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
-			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
+			&graphql.ArgumentConfig{Name: "aStr", Type: graphql.String},
+			&graphql.ArgumentConfig{Name: "aInt", Type: graphql.Int},
 		},
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			b, err := json.Marshal(p.Args)
@@ -132,8 +133,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			},
 		}),
 		Args: graphql.FieldConfigArgument{
-			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
-			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
+			&graphql.ArgumentConfig{Name: "aStr", Type: graphql.String},
+			&graphql.ArgumentConfig{Name: "aInt", Type: graphql.Int},
 		},
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			aStr, _ := p.Args["aStr"].(string)
@@ -208,8 +209,8 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_With
 			},
 		}),
 		Args: graphql.FieldConfigArgument{
-			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
-			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
+			&graphql.ArgumentConfig{Name: "aStr", Type: graphql.String},
+			&graphql.ArgumentConfig{Name: "aInt", Type: graphql.Int},
 		},
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			aStr, _ := p.Args["aStr"].(string)

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -99,10 +99,12 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 			"pic": &graphql.Field{
 				Type: blogImage,
 				Args: graphql.FieldConfigArgument{
-					"width": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "width",
 						Type: graphql.Int,
 					},
-					"height": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "height",
 						Type: graphql.Int,
 					},
 				},
@@ -152,7 +154,8 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 			"article": &graphql.Field{
 				Type: blogArticle,
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "id",
 						Type: graphql.ID,
 					},
 				},

--- a/executor_schema_test.go
+++ b/executor_schema_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 // TODO: have a separate package for other tests for eg `parser`

--- a/executor_test.go
+++ b/executor_test.go
@@ -142,7 +142,8 @@ func TestExecutesArbitraryCode(t *testing.T) {
 			},
 			"pic": &graphql.Field{
 				Args: graphql.FieldConfigArgument{
-					"size": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "size",
 						Type: graphql.Int,
 					},
 				},
@@ -419,10 +420,12 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 			Fields: graphql.Fields{
 				"b": &graphql.Field{
 					Args: graphql.FieldConfigArgument{
-						"numArg": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "numArg",
 							Type: graphql.Int,
 						},
-						"stringArg": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "stringArg",
 							Type: graphql.String,
 						},
 					},
@@ -1330,19 +1333,24 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 				"field": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
-						"a": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "a",
 							Type: graphql.Boolean,
 						},
-						"b": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "b",
 							Type: graphql.Boolean,
 						},
-						"c": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "c",
 							Type: graphql.Boolean,
 						},
-						"d": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "d",
 							Type: graphql.Int,
 						},
-						"e": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "e",
 							Type: graphql.Int,
 						},
 					},
@@ -1601,7 +1609,8 @@ func TestQuery_InputObjectUsesFieldDefaultValueFn(t *testing.T) {
 			"a": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"foo": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "foo",
 						Type: graphql.NewNonNull(inputType),
 					},
 				},
@@ -1651,7 +1660,8 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 			"foo": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"f": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "f",
 						Type: graphql.String,
 					},
 				},
@@ -1662,7 +1672,8 @@ func TestMutation_ExecutionAddsErrorsFromFieldResolveFn(t *testing.T) {
 			"bar": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"b": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "b",
 						Type: graphql.String,
 					},
 				},
@@ -1708,7 +1719,8 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 			"foo": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"f": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "f",
 						Type: graphql.String,
 					},
 				},
@@ -1719,7 +1731,8 @@ func TestMutation_ExecutionDoesNotAddErrorsFromFieldResolveFn(t *testing.T) {
 			"bar": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"b": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "b",
 						Type: graphql.String,
 					},
 				},

--- a/executor_test.go
+++ b/executor_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestExecutesArbitraryCode(t *testing.T) {

--- a/extensions.go
+++ b/extensions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/dagger/graphql/gqlerrors"
 )
 
 type (

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func tinit(t *testing.T) graphql.Schema {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/graphql-go/graphql
+module github.com/dagger/graphql
 
 go 1.13

--- a/gqlerrors/error.go
+++ b/gqlerrors/error.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/source"
 )
 
 type Error struct {

--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -3,7 +3,7 @@ package gqlerrors
 import (
 	"errors"
 
-	"github.com/graphql-go/graphql/language/location"
+	"github.com/dagger/graphql/language/location"
 )
 
 type ExtendedError interface {

--- a/gqlerrors/located.go
+++ b/gqlerrors/located.go
@@ -2,7 +2,7 @@ package gqlerrors
 
 import (
 	"errors"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/language/ast"
 )
 
 // NewLocatedError creates a graphql.Error with location info

--- a/gqlerrors/syntax.go
+++ b/gqlerrors/syntax.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/source"
 )
 
 func NewSyntaxError(s *source.Source, position int, description string) *Error {

--- a/graphql.go
+++ b/graphql.go
@@ -3,9 +3,9 @@ package graphql
 import (
 	"context"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/source"
 )
 
 type Params struct {

--- a/graphql_bench_test.go
+++ b/graphql_bench_test.go
@@ -3,8 +3,8 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/benchutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/benchutil"
 )
 
 type B struct {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -167,7 +167,7 @@ func TestThreadsContextFromParamsThrough(t *testing.T) {
 				"value": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
-						"key": &graphql.ArgumentConfig{Type: graphql.String},
+						&graphql.ArgumentConfig{Name: "key", Type: graphql.String},
 					},
 					Resolve: extractFieldFromContextFn,
 				},
@@ -240,7 +240,7 @@ func TestEmptyStringIsNotNull(t *testing.T) {
 				"checkEmptyArg": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
-						"arg": &graphql.ArgumentConfig{Type: graphql.String},
+						&graphql.ArgumentConfig{Name: "arg", Type: graphql.String},
 					},
 					Resolve: checkForEmptyString,
 				},

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 type T struct {

--- a/introspection.go
+++ b/introspection.go
@@ -522,7 +522,8 @@ func init() {
 	TypeType.AddFieldConfig("fields", &Field{
 		Type: NewList(NewNonNull(FieldType)),
 		Args: FieldConfigArgument{
-			"includeDeprecated": &ArgumentConfig{
+			&ArgumentConfig{
+				Name:         "includeDeprecated",
 				Type:         Boolean,
 				DefaultValue: false,
 			},
@@ -587,7 +588,8 @@ func init() {
 	TypeType.AddFieldConfig("enumValues", &Field{
 		Type: NewList(NewNonNull(EnumValueType)),
 		Args: FieldConfigArgument{
-			"includeDeprecated": &ArgumentConfig{
+			&ArgumentConfig{
+				Name:         "includeDeprecated",
 				Type:         Boolean,
 				DefaultValue: false,
 			},

--- a/introspection.go
+++ b/introspection.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/printer"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/printer"
 )
 
 const (

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -853,7 +853,8 @@ func TestIntrospection_ExecutesAnInputObject(t *testing.T) {
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"complex": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "complex",
 						Type: testInputObject,
 					},
 				},

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -3,10 +3,10 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 func g(t *testing.T, p graphql.Params) *graphql.Result {

--- a/language/ast/arguments.go
+++ b/language/ast/arguments.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // Argument implements Node

--- a/language/ast/definitions.go
+++ b/language/ast/definitions.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 type Definition interface {

--- a/language/ast/directives.go
+++ b/language/ast/directives.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // Directive implements Node

--- a/language/ast/document.go
+++ b/language/ast/document.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // Document implements Node

--- a/language/ast/location.go
+++ b/language/ast/location.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/language/source"
 )
 
 type Location struct {

--- a/language/ast/name.go
+++ b/language/ast/name.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // Name implements Node

--- a/language/ast/selections.go
+++ b/language/ast/selections.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 type Selection interface {

--- a/language/ast/type_definitions.go
+++ b/language/ast/type_definitions.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // DescribableNode are nodes that have descriptions associated with them.

--- a/language/ast/types.go
+++ b/language/ast/types.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 type Type interface {

--- a/language/ast/values.go
+++ b/language/ast/values.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 type Value interface {

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/source"
 )
 
 type TokenKind int

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/language/source"
 )
 
 type Test struct {

--- a/language/location/location.go
+++ b/language/location/location.go
@@ -3,7 +3,7 @@ package location
 import (
 	"regexp"
 
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/language/source"
 )
 
 type SourceLocation struct {

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -3,10 +3,10 @@ package parser
 import (
 	"fmt"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/lexer"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/lexer"
+	"github.com/dagger/graphql/language/source"
 )
 
 type parseFn func(parser *Parser) (interface{}, error)
@@ -1566,7 +1566,8 @@ func unexpectedEmpty(parser *Parser, beginLoc int, openKind, closeKind lexer.Tok
 	return gqlerrors.NewSyntaxError(parser.Source, beginLoc, description)
 }
 
-//  Returns list of parse nodes, determined by
+//	Returns list of parse nodes, determined by
+//
 // the parseFn. This list begins with a lex token of openKind
 // and ends with a lex token of closeKind. Advances the parser
 // to the next lex token after the closing token.

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/language/source"
 )
 
 func TestBadToken(t *testing.T) {

--- a/language/parser/schema_parser_test.go
+++ b/language/parser/schema_parser_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/source"
 )
 
 func parse(t *testing.T, query string) *ast.Document {

--- a/language/printer/printer.go
+++ b/language/printer/printer.go
@@ -7,8 +7,8 @@ import (
 
 	"reflect"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/visitor"
 )
 
 func getMapValue(m map[string]interface{}, key string) interface{} {

--- a/language/printer/printer_test.go
+++ b/language/printer/printer_test.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/testutil"
 )
 
 func parse(t *testing.T, query string) *ast.Document {

--- a/language/printer/schema_printer_test.go
+++ b/language/printer/schema_printer_test.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestSchemaPrinter_PrintsMinimalAST(t *testing.T) {

--- a/language/typeInfo/type_info.go
+++ b/language/typeInfo/type_info.go
@@ -1,7 +1,7 @@
 package typeInfo
 
 import (
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/language/ast"
 )
 
 // TypeInfoI defines the interface for TypeInfo Implementation

--- a/language/visitor/visitor.go
+++ b/language/visitor/visitor.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/typeInfo"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/typeInfo"
 )
 
 const (

--- a/language/visitor/visitor_test.go
+++ b/language/visitor/visitor_test.go
@@ -7,13 +7,13 @@ import (
 
 	"fmt"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/language/visitor"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/language/visitor"
+	"github.com/dagger/graphql/testutil"
 )
 
 func parse(t *testing.T, query string) *ast.Document {

--- a/lists_test.go
+++ b/lists_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 func checkList(t *testing.T, testType graphql.Type, testData interface{}, expected *graphql.Result) {

--- a/located.go
+++ b/located.go
@@ -3,8 +3,8 @@ package graphql
 import (
 	"errors"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
 )
 
 func NewLocatedError(err interface{}, nodes []ast.Node) *gqlerrors.Error {

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -4,10 +4,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 // testNumberHolder maps to numberHolderType

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -62,7 +62,8 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 			"immediatelyChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
-					"newNumber": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "newNumber",
 						Type: graphql.Int,
 					},
 				},
@@ -76,7 +77,8 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 			"promiseToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
-					"newNumber": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "newNumber",
 						Type: graphql.Int,
 					},
 				},
@@ -90,7 +92,8 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 			"failToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
-					"newNumber": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "newNumber",
 						Type: graphql.Int,
 					},
 				},
@@ -104,7 +107,8 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 			"promiseAndFailToChangeTheNumber": &graphql.Field{
 				Type: numberHolderType,
 				Args: graphql.FieldConfigArgument{
-					"newNumber": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "newNumber",
 						Type: graphql.Int,
 					},
 				},

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -4,10 +4,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 var syncError = "sync"

--- a/race_test.go
+++ b/race_test.go
@@ -23,7 +23,7 @@ func TestRace(t *testing.T) {
 			"runtime"
 			"sync"
 
-			"github.com/graphql-go/graphql"
+			"github.com/dagger/graphql"
 		)
 
 		func main() {

--- a/rules.go
+++ b/rules.go
@@ -7,11 +7,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/language/visitor"
 )
 
 // SpecifiedRules set includes all validation rules defined by the GraphQL spec.

--- a/rules_arguments_of_correct_type_test.go
+++ b/rules_arguments_of_correct_type_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_ArgValuesOfCorrectType_ValidValue_GoodIntValue(t *testing.T) {

--- a/rules_default_values_of_correct_type_test.go
+++ b/rules_default_values_of_correct_type_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_VariableDefaultValuesOfCorrectType_VariablesWithNoDefaultValues(t *testing.T) {

--- a/rules_fields_on_correct_type_test.go
+++ b/rules_fields_on_correct_type_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_FieldsOnCorrectType_ObjectFieldSelection(t *testing.T) {

--- a/rules_fragments_on_composite_types_test.go
+++ b/rules_fragments_on_composite_types_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_FragmentsOnCompositeTypes_ObjectIsValidFragmentType(t *testing.T) {

--- a/rules_known_argument_names_test.go
+++ b/rules_known_argument_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_KnownArgumentNames_SingleArgIsKnown(t *testing.T) {

--- a/rules_known_directives_rule_test.go
+++ b/rules_known_directives_rule_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_KnownDirectives_WithNoDirectives(t *testing.T) {

--- a/rules_known_fragment_names_test.go
+++ b/rules_known_fragment_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_KnownFragmentNames_KnownFragmentNamesAreValid(t *testing.T) {

--- a/rules_known_type_names_test.go
+++ b/rules_known_type_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_KnownTypeNames_KnownTypeNamesAreValid(t *testing.T) {

--- a/rules_lone_anonymous_operation_rule_test.go
+++ b/rules_lone_anonymous_operation_rule_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_AnonymousOperationMustBeAlone_NoOperations(t *testing.T) {

--- a/rules_no_fragment_cycles_test.go
+++ b/rules_no_fragment_cycles_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_NoCircularFragmentSpreads_SingleReferenceIsValid(t *testing.T) {

--- a/rules_no_undefined_variables_test.go
+++ b/rules_no_undefined_variables_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_NoUndefinedVariables_AllVariablesDefined(t *testing.T) {

--- a/rules_no_unused_fragments_test.go
+++ b/rules_no_unused_fragments_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_NoUnusedFragments_AllFragmentNamesAreUsed(t *testing.T) {

--- a/rules_no_unused_variables_test.go
+++ b/rules_no_unused_variables_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_NoUnusedVariables_UsesAllVariables(t *testing.T) {

--- a/rules_overlapping_fields_can_be_merged.go
+++ b/rules_overlapping_fields_can_be_merged.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/graphql-go/graphql/language/printer"
-	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
+	"github.com/dagger/graphql/language/printer"
+	"github.com/dagger/graphql/language/visitor"
 )
 
 func fieldsConflictMessage(responseName string, reason conflictReason) string {

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_OverlappingFieldsCanBeMerged_UniqueFields(t *testing.T) {

--- a/rules_possible_fragment_spreads_test.go
+++ b/rules_possible_fragment_spreads_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_PossibleFragmentSpreads_OfTheSameObject(t *testing.T) {

--- a/rules_provided_non_null_arguments_test.go
+++ b/rules_provided_non_null_arguments_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_ProvidedNonNullArguments_IgnoresUnknownArguments(t *testing.T) {

--- a/rules_scalar_leafs_test.go
+++ b/rules_scalar_leafs_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_ScalarLeafs_ValidScalarSelection(t *testing.T) {

--- a/rules_unique_argument_names_test.go
+++ b/rules_unique_argument_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_UniqueArgumentNames_NoArgumentsOnField(t *testing.T) {

--- a/rules_unique_fragment_names_test.go
+++ b/rules_unique_fragment_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_UniqueFragmentNames_NoFragments(t *testing.T) {

--- a/rules_unique_input_field_names_test.go
+++ b/rules_unique_input_field_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_UniqueInputFieldNames_InputObjectWithFields(t *testing.T) {

--- a/rules_unique_operation_names_test.go
+++ b/rules_unique_operation_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_UniqueOperationNames_NoOperations(t *testing.T) {

--- a/rules_unique_variable_names_test.go
+++ b/rules_unique_variable_names_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_UniqueVariableNames_UniqueVariableNames(t *testing.T) {

--- a/rules_variables_are_input_types_test.go
+++ b/rules_variables_are_input_types_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_VariablesAreInputTypes_(t *testing.T) {

--- a/rules_variables_in_allowed_position_test.go
+++ b/rules_variables_in_allowed_position_test.go
@@ -3,9 +3,9 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestValidate_VariablesInAllowedPosition_BooleanToBoolean(t *testing.T) {

--- a/scalars.go
+++ b/scalars.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql/language/ast"
 )
 
 // As per the GraphQL Spec, Integers are only treated as valid when a valid

--- a/scalars_parse_test.go
+++ b/scalars_parse_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/language/ast"
 )
 
 func TestTypeSystem_Scalar_ParseValueOutputDateTime(t *testing.T) {

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 type intSerializationTest struct {

--- a/schema.go
+++ b/schema.go
@@ -16,21 +16,23 @@ type TypeMap map[string]Type
 // query, mutation (optional) and subscription (optional). A schema definition is then supplied to the
 // validator and executor.
 // Example:
-//     myAppSchema, err := NewSchema(SchemaConfig({
-//       Query: MyAppQueryRootType,
-//       Mutation: MyAppMutationRootType,
-//       Subscription: MyAppSubscriptionRootType,
-//     });
+//
+//	myAppSchema, err := NewSchema(SchemaConfig({
+//	  Query: MyAppQueryRootType,
+//	  Mutation: MyAppMutationRootType,
+//	  Subscription: MyAppSubscriptionRootType,
+//	});
+//
 // Note: If an array of `directives` are provided to GraphQLSchema, that will be
 // the exact list of directives represented and allowed. If `directives` is not
 // provided then a default set of the specified directives (e.g. @include and
 // @skip) will be used. If you wish to provide *additional* directives to these
 // specified directives, you must explicitly declare them. Example:
 //
-//     const MyAppSchema = new GraphQLSchema({
-//       ...
-//       directives: specifiedDirectives.concat([ myCustomDirective ]),
-//     })
+//	const MyAppSchema = new GraphQLSchema({
+//	  ...
+//	  directives: specifiedDirectives.concat([ myCustomDirective ]),
+//	})
 type Schema struct {
 	typeMap    TypeMap
 	directives []*Directive
@@ -145,8 +147,8 @@ func NewSchema(config SchemaConfig) (Schema, error) {
 	return schema, nil
 }
 
-//Added Check implementation of interfaces at runtime..
-//Add Implementations at Runtime..
+// Added Check implementation of interfaces at runtime..
+// Add Implementations at Runtime..
 func (gq *Schema) AddImplementation() error {
 
 	// Keep track of all implementations by interface name.
@@ -181,8 +183,8 @@ func (gq *Schema) AddImplementation() error {
 	return nil
 }
 
-//Edited. To check add Types at RunTime..
-//Append Runtime schema to typeMap
+// Edited. To check add Types at RunTime..
+// Append Runtime schema to typeMap
 func (gq *Schema) AppendType(objectType Type) error {
 	if objectType.Error() != nil {
 		return objectType.Error()

--- a/subscription.go
+++ b/subscription.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/source"
 )
 
 // SubscribeParams parameters for subscribing

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestSchemaSubscribe(t *testing.T) {

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -20,7 +20,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -33,7 +34,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -46,7 +48,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -76,7 +79,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -93,10 +97,12 @@ func init() {
 			"doesKnowCommand": &graphql.Field{
 				Type: graphql.Boolean,
 				Args: graphql.FieldConfigArgument{
-					"dogCommand": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "dogCommand",
 						Type: dogCommandEnum,
 					},
-					"nextDogCommand": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "nextDogCommand",
 						Type: dogCommandEnum,
 					},
 				},
@@ -104,7 +110,8 @@ func init() {
 			"isHousetrained": &graphql.Field{
 				Type: graphql.Boolean,
 				Args: graphql.FieldConfigArgument{
-					"atOtherHomes": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:         "atOtherHomes",
 						Type:         graphql.Boolean,
 						DefaultValue: true,
 					},
@@ -113,10 +120,12 @@ func init() {
 			"isAtLocation": &graphql.Field{
 				Type: graphql.Boolean,
 				Args: graphql.FieldConfigArgument{
-					"x": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "x",
 						Type: graphql.Int,
 					},
-					"y": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "y",
 						Type: graphql.Int,
 					},
 				},
@@ -155,7 +164,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -207,7 +217,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -238,7 +249,8 @@ func init() {
 			"name": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"surname": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "surname",
 						Type: graphql.Boolean,
 					},
 				},
@@ -303,7 +315,8 @@ func init() {
 			"intArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"intArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "intArg",
 						Type: graphql.Int,
 					},
 				},
@@ -311,7 +324,8 @@ func init() {
 			"nonNullIntArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"nonNullIntArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "nonNullIntArg",
 						Type: graphql.NewNonNull(graphql.Int),
 					},
 				},
@@ -319,7 +333,8 @@ func init() {
 			"stringArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"stringArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "stringArg",
 						Type: graphql.String,
 					},
 				},
@@ -327,7 +342,8 @@ func init() {
 			"booleanArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"booleanArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "booleanArg",
 						Type: graphql.Boolean,
 					},
 				},
@@ -335,7 +351,8 @@ func init() {
 			"enumArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"enumArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "enumArg",
 						Type: furColorEnum,
 					},
 				},
@@ -343,7 +360,8 @@ func init() {
 			"floatArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"floatArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "floatArg",
 						Type: graphql.Float,
 					},
 				},
@@ -351,7 +369,8 @@ func init() {
 			"idArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"idArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "idArg",
 						Type: graphql.ID,
 					},
 				},
@@ -359,7 +378,8 @@ func init() {
 			"stringListArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"stringListArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "stringListArg",
 						Type: graphql.NewList(graphql.String),
 					},
 				},
@@ -367,7 +387,8 @@ func init() {
 			"complexArgField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"complexArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "complexArg",
 						Type: complexInputObject,
 					},
 				},
@@ -375,10 +396,12 @@ func init() {
 			"multipleReqs": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"req1": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "req1",
 						Type: graphql.NewNonNull(graphql.Int),
 					},
-					"req2": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "req2",
 						Type: graphql.NewNonNull(graphql.Int),
 					},
 				},
@@ -386,11 +409,13 @@ func init() {
 			"multipleOpts": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"opt1": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:         "opt1",
 						Type:         graphql.Int,
 						DefaultValue: 0,
 					},
-					"opt2": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:         "opt2",
 						Type:         graphql.Int,
 						DefaultValue: 0,
 					},
@@ -399,17 +424,21 @@ func init() {
 			"multipleOptAndReq": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"req1": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "req1",
 						Type: graphql.NewNonNull(graphql.Int),
 					},
-					"req2": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "req2",
 						Type: graphql.NewNonNull(graphql.Int),
 					},
-					"opt1": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:         "opt1",
 						Type:         graphql.Int,
 						DefaultValue: 0,
 					},
-					"opt2": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:         "opt2",
 						Type:         graphql.Int,
 						DefaultValue: 0,
 					},
@@ -422,7 +451,8 @@ func init() {
 		Fields: graphql.Fields{
 			"human": &graphql.Field{
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "id",
 						Type: graphql.ID,
 					},
 				},

--- a/testutil/rules_test_harness.go
+++ b/testutil/rules_test_harness.go
@@ -3,11 +3,11 @@ package testutil
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/source"
 )
 
 var TestSchema *graphql.Schema

--- a/testutil/subscription.go
+++ b/testutil/subscription.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/graphql-go/graphql"
+	"github.com/dagger/graphql"
 )
 
 // TestResponse models the expected response

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -282,7 +282,8 @@ func init() {
 			"hero": &graphql.Field{
 				Type: characterInterface,
 				Args: graphql.FieldConfigArgument{
-					"episode": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "episode",
 						Description: "If omitted, returns the hero of the whole saga. If " +
 							"provided, returns the hero of that particular episode.",
 						Type: episodeEnum,
@@ -295,7 +296,8 @@ func init() {
 			"human": &graphql.Field{
 				Type: humanType,
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:        "id",
 						Description: "id of the human",
 						Type:        graphql.NewNonNull(graphql.String),
 					},
@@ -311,7 +313,8 @@ func init() {
 			"droid": &graphql.Field{
 				Type: droidType,
 				Args: graphql.FieldConfigArgument{
-					"id": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name:        "id",
 						Description: "id of the droid",
 						Type:        graphql.NewNonNull(graphql.String),
 					},

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/parser"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/parser"
 )
 
 var (

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -3,7 +3,7 @@ package testutil_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql/testutil"
 )
 
 func TestSubsetSlice_Simple(t *testing.T) {

--- a/type_info.go
+++ b/type_info.go
@@ -1,8 +1,8 @@
 package graphql
 
 import (
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
 )
 
 // TODO: can move TypeInfo to a utils package if there ever is one

--- a/types.go
+++ b/types.go
@@ -1,7 +1,7 @@
 package graphql
 
 import (
-	"github.com/graphql-go/graphql/gqlerrors"
+	"github.com/dagger/graphql/gqlerrors"
 )
 
 // type Schema interface{}

--- a/union_interface_test.go
+++ b/union_interface_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 type testNamedType interface {

--- a/util.go
+++ b/util.go
@@ -11,9 +11,11 @@ const TAG = "json"
 
 // can't take recursive slice type
 // e.g
-// type Person struct{
-//	Friends []Person
-// }
+//
+//	type Person struct{
+//		Friends []Person
+//	}
+//
 // it will throw panic stack-overflow
 func BindFields(obj interface{}) Fields {
 	t := reflect.TypeOf(obj)

--- a/util.go
+++ b/util.go
@@ -163,15 +163,16 @@ func extractTag(tag reflect.StructTag) string {
 // lazy way of binding args
 func BindArg(obj interface{}, tags ...string) FieldConfigArgument {
 	v := reflect.Indirect(reflect.ValueOf(obj))
-	var config = make(FieldConfigArgument)
+	var config = FieldConfigArgument{}
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Type().Field(i)
 
 		mytag := extractTag(field.Tag)
 		if inArray(tags, mytag) {
-			config[mytag] = &ArgumentConfig{
+			config = append(config, &ArgumentConfig{
+				Name: mytag,
 				Type: getGraphType(field.Type),
-			}
+			})
 		}
 	}
 	return config

--- a/util_test.go
+++ b/util_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/testutil"
 )
 
 type Person struct {

--- a/validation_test.go
+++ b/validation_test.go
@@ -124,7 +124,8 @@ func schemaWithInputObject(ttype graphql.Input) (graphql.Schema, error) {
 				"f": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
-						"args": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "args",
 							Type: ttype,
 						},
 					},
@@ -226,7 +227,8 @@ func schemaWithArgOfType(ttype graphql.Type) (graphql.Schema, error) {
 			"badField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"badArg": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "badArg",
 						Type: ttype,
 					},
 				},
@@ -261,7 +263,8 @@ func schemaWithInputFieldOfType(ttype graphql.Type) (graphql.Schema, error) {
 				"f": &graphql.Field{
 					Type: graphql.String,
 					Args: graphql.FieldConfigArgument{
-						"badArg": &graphql.ArgumentConfig{
+						&graphql.ArgumentConfig{
+							Name: "badArg",
 							Type: badInputObject,
 						},
 					},
@@ -495,7 +498,8 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_AcceptsFieldArgsWithValidNames
 			"goodField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"goodArgs": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "goodArgs",
 						Type: graphql.String,
 					},
 				},
@@ -513,7 +517,8 @@ func TestTypeSystem_FieldsArgsMustBeProperlyNamed_RejectsFieldArgWithInvalidName
 			"badField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"bad-name-with-dashes": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "bad-name-with-dashes",
 						Type: graphql.String,
 					},
 				},
@@ -533,7 +538,8 @@ func TestTypeSystem_FieldsArgsMustBeObjects_AcceptsAnObjectTypeWithFieldArgs(t *
 			"goodField": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"goodArgs": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "goodArgs",
 						Type: graphql.String,
 					},
 				},
@@ -1130,7 +1136,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1144,7 +1151,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1166,7 +1174,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1180,7 +1189,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1205,7 +1215,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1219,10 +1230,12 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
-					"anotherInput": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "anotherInput",
 						Type: graphql.String,
 					},
 				},
@@ -1244,7 +1257,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1258,10 +1272,12 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWhi
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
-					"anotherInput": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "anotherInput",
 						Type: graphql.NewNonNull(graphql.String),
 					},
 				},
@@ -1284,7 +1300,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1449,7 +1466,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectMis
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1481,7 +1499,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: graphql.String,
 					},
 				},
@@ -1495,7 +1514,8 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_RejectsAnObjectWit
 			"field": &graphql.Field{
 				Type: graphql.String,
 				Args: graphql.FieldConfigArgument{
-					"input": &graphql.ArgumentConfig{
+					&graphql.ArgumentConfig{
+						Name: "input",
 						Type: someScalarType,
 					},
 				},

--- a/validation_test.go
+++ b/validation_test.go
@@ -3,8 +3,8 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/language/ast"
 )
 
 var someScalarType = graphql.NewScalar(graphql.ScalarConfig{

--- a/validator.go
+++ b/validator.go
@@ -1,10 +1,10 @@
 package graphql
 
 import (
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
+	"github.com/dagger/graphql/language/visitor"
 )
 
 type ValidationResult struct {

--- a/validator_test.go
+++ b/validator_test.go
@@ -3,13 +3,13 @@ package graphql_test
 import (
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/source"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/language/parser"
+	"github.com/dagger/graphql/language/source"
+	"github.com/dagger/graphql/testutil"
 )
 
 func expectValid(t *testing.T, schema *graphql.Schema, queryString string) {

--- a/values.go
+++ b/values.go
@@ -8,10 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/kinds"
-	"github.com/graphql-go/graphql/language/printer"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/kinds"
+	"github.com/dagger/graphql/language/printer"
 )
 
 // Prepares an object map of variableValues of the correct type based on the

--- a/variables_test.go
+++ b/variables_test.go
@@ -83,7 +83,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"fieldWithObjectInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: testInputObject,
 				},
 			},
@@ -92,7 +93,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"fieldWithNullableStringInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.String,
 				},
 			},
@@ -101,7 +103,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"fieldWithNonNullableStringInput": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.NewNonNull(graphql.String),
 				},
 			},
@@ -110,7 +113,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"fieldWithDefaultArgumentValue": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name:         "input",
 					Type:         graphql.String,
 					DefaultValue: "Hello World",
 				},
@@ -120,7 +124,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"fieldWithNestedInputObject": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name:         "input",
 					Type:         testNestedInputObject,
 					DefaultValue: "Hello World",
 				},
@@ -130,7 +135,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"list": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.NewList(graphql.String),
 				},
 			},
@@ -139,7 +145,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"nnList": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.NewNonNull(graphql.NewList(graphql.String)),
 				},
 			},
@@ -148,7 +155,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"listNN": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.NewList(graphql.NewNonNull(graphql.String)),
 				},
 			},
@@ -157,7 +165,8 @@ var testType *graphql.Object = graphql.NewObject(graphql.ObjectConfig{
 		"nnListNN": &graphql.Field{
 			Type: graphql.String,
 			Args: graphql.FieldConfigArgument{
-				"input": &graphql.ArgumentConfig{
+				&graphql.ArgumentConfig{
+					Name: "input",
 					Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.String))),
 				},
 			},

--- a/variables_test.go
+++ b/variables_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/graphql-go/graphql"
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
-	"github.com/graphql-go/graphql/language/location"
-	"github.com/graphql-go/graphql/testutil"
+	"github.com/dagger/graphql"
+	"github.com/dagger/graphql/gqlerrors"
+	"github.com/dagger/graphql/language/ast"
+	"github.com/dagger/graphql/language/location"
+	"github.com/dagger/graphql/testutil"
 )
 
 var testComplexScalar *graphql.Scalar = graphql.NewScalar(graphql.ScalarConfig{


### PR DESCRIPTION
   This change allows to preserve the order in which arguments have been
   defined in introspection queries.
