### PR TITLE
support any value as root object

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -17,7 +17,7 @@ type Params struct {
 
 	// The value provided as the first argument to resolver functions on the top
 	// level type (e.g. the query object type).
-	RootObject map[string]any
+	RootObject any
 
 	// A mapping of variable name to runtime value to use for all variables
 	// defined in the requestString.


### PR DESCRIPTION
Limiting this to `map[string]any` is pointless and prevents us from having a special root type that conforms to an IDable interface.

needed by https://github.com/dagger/dagger/pull/6158